### PR TITLE
Fix ignore of small avatars

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -58,7 +58,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20181209.02'
+VERSION = '20181209.03'
 USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html; ArchiveTeam)'
 TRACKER_ID = 'tumblr'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -48,6 +48,7 @@ allowed = function(url, parenturl)
   or string.match(url, "^https?://assets%.tumblr%.com/%p+%d+")
   or string.match(url, "^https?://static%.tumblr%.com/%p+%d+")
   or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_64%.pnj")
+  or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_64%.gif")
   or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_16%.pnj")
   or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_16%.gif")
   or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/post/")
@@ -105,6 +106,14 @@ wget.callbacks.download_child_p = function(urlpos, parent, depth, start_url_pars
   
   if string.find(url, "px.srvcs.tumblr.com") then
     -- Ignore px.srvcs.tumblr.com tracking domain
+    return false
+  end
+
+  if string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_64%.pnj")
+  or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_64%.gif")
+  or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_16%.pnj")
+  or string.match(url, "^https?://[0-9]+%.media%.tumblr%.com/avatar_[a-zA-Z0-9]+_16%.gif") then
+    -- Ignore small avatars (16x16 and 64x64)
     return false
   end
   


### PR DESCRIPTION
Previously, there was a logic error in the condition to ignore small
avatars. Although the pattern was properly excluded, the
`download_child_p` hook would always accept anything that wasn't
expected to be HTML: `... allowed(url, parent["url"]) or html == 0')`.

To fix this, I add an additional check in `download_child_p` before
the call to `allowed` to ensure that avatars are excluded.  The
`get_urls` hook didn't have this error, so no updates were necessary
there and the existing `allowed` call works as expected.

I also exclude 64 pixel GIF avatars to be thorough. This was already
done for the 16 pixel ones, but not the 64 pixel ones.