### PR TITLE
Update to 20181210.04; Removing reblog links

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -58,7 +58,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20181210.03'
+VERSION = '20181210.04'
 USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html; ArchiveTeam)'
 TRACKER_ID = 'tumblr'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -59,7 +59,7 @@ allowed = function(url, parenturl)
   or string.match(url, "^https?://assets%.tumblr%.com/client")
   or string.match(url, "^https?://static%.tumblr%.com/[%u%p%l]+")
   or string.match(url, "ios%-app://")
-  string.match(url, "^https?://" .. item_value .. "%.tumblr%.com/reblog") then
+  or string.match(url, "^https?://" .. item_value .. "%.tumblr%.com/reblog") then
     return false
   end
 

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -58,7 +58,8 @@ allowed = function(url, parenturl)
   or string.match(url, "^https?://assets%.tumblr%.com/filter%-by")
   or string.match(url, "^https?://assets%.tumblr%.com/client")
   or string.match(url, "^https?://static%.tumblr%.com/[%u%p%l]+")
-  or string.match(url, "ios%-app://") then
+  or string.match(url, "ios%-app://")
+  string.match(url, "^https?://" .. item_value .. "%.tumblr%.com/reblog") then
     return false
   end
 


### PR DESCRIPTION
Tested with tumblr-blog:9volt-art
Does appear to work, I don't see any reblog links in stdout