### PR TITLE
Update to 20181213.01

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -59,7 +59,7 @@ if not WGET_LUA:
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
 
-VERSION = '20181212.03'
+VERSION = '20181213.01'
 USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html; ArchiveTeam)'
 TRACKER_ID = 'tumblr'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -283,7 +283,9 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     or string.match(url["host"], "static%.tumblr%.com")
     or string.match(url["host"], "[a-z0-9]+%.media%.tumblr%.com")
     or string.match(url["host"], "vtt%.tumblr%.com")
-    or string.match(url["host"], "www%.tumblr%.com") then
+    or string.match(url["host"], "www%.tumblr%.com")
+    or string.match(url["host"], "counter%.website%-hit%-counters%.com")
+    or string.match(url["url"], "^https?://".. item_value .."%.tumblr%.com/services") then
       io.stdout:write("Server returned " ..http_stat.statcode.." ("..err.."). Skipping.\n")
       tries = 0
       return wget.actions.EXIT

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -264,7 +264,8 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
       io.stdout:write("\nI give up...\n")
       io.stdout:flush()
       tries = 0
-      if string.match(url["url"], "_%d+.[pjg][npi][ggf]$") then
+      if string.match(url["url"], "_%d+.[pjg][npi][ggf]$")
+      or string.match(url["url"], "%.[pjg][npi][ggf]$") then
         return wget.actions.EXIT
       end
       if allowed(url["url"], nil) then
@@ -288,7 +289,8 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     or string.match(url["url"], "^https?://".. item_value .."%.tumblr%.com/services")
     or string.match(url["host"], "adult%-anal%-party%.com")
     or string.match(url["host"], "wielkie%-hu215%.metal%-invest%.pl")
-    or string.match(url["host"], "de05%.cdn%.z5o%.net") then
+    or string.match(url["host"], "de05%.cdn%.z5o%.net")
+    or string.match(url["url"], "%.[pjg][npi][ggf]$") then
       io.stdout:write("Server returned " ..http_stat.statcode.." ("..err.."). Skipping.\n")
       tries = 0
       return wget.actions.EXIT

--- a/tumblr.lua
+++ b/tumblr.lua
@@ -285,7 +285,10 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     or string.match(url["host"], "vtt%.tumblr%.com")
     or string.match(url["host"], "www%.tumblr%.com")
     or string.match(url["host"], "counter%.website%-hit%-counters%.com")
-    or string.match(url["url"], "^https?://".. item_value .."%.tumblr%.com/services") then
+    or string.match(url["url"], "^https?://".. item_value .."%.tumblr%.com/services")
+    or string.match(url["host"], "adult%-anal%-party%.com")
+    or string.match(url["host"], "wielkie%-hu215%.metal%-invest%.pl")
+    or string.match(url["host"], "de05%.cdn%.z5o%.net") then
       io.stdout:write("Server returned " ..http_stat.statcode.." ("..err.."). Skipping.\n")
       tries = 0
       return wget.actions.EXIT


### PR DESCRIPTION
Ignoring status codes 400-403, 405-499, 500+ and 0 on jpg, gif and pnj from urls